### PR TITLE
Ignore missing languages and force plain-text.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ function attacher(options) {
   var settings = options || {};
   var detect = settings.subset !== false;
   var prefix = settings.prefix;
+  var ignoreMissing = settings.ignoreMissing;
+  var plainText = settings.plainText || [];
   var name = 'hljs';
   var pos;
 
@@ -35,7 +37,7 @@ function attacher(options) {
 
     lang = language(node);
 
-    if (lang === false || (!lang && !detect)) {
+    if (lang === false || (!lang && !detect) || plainText.indexOf(lang) !== -1) {
       return;
     }
 
@@ -47,14 +49,21 @@ function attacher(options) {
       props.className.unshift(name);
     }
 
-    if (lang) {
-      result = lowlight.highlight(lang, toString(node), options);
-    } else {
-      result = lowlight.highlightAuto(toString(node), options);
+    try {
+      if (lang) {
+        result = lowlight.highlight(lang, toString(node), options);
+      } else {
+        result = lowlight.highlightAuto(toString(node), options);
 
-      if (result.language) {
-        props.className.push('language-' + result.language);
+        if (result.language) {
+          props.className.push('language-' + result.language);
+        }
       }
+    } catch (err) {
+      if (ignoreMissing === true) {
+        return;
+      }
+      throw err;
     }
 
     node.children = result.value;

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,16 @@ Will auto-detect the syntax language otherwise.
 check when auto-detecting.  Pass `false` to not highlight code without
 language classes.
 
+###### `options.ignoreMissing`
+
+`boolean`, default: `false`.  Pass `true` to not highlight code with
+unrecognized language classes.
+
+###### `options.plainText`
+
+`Array.<string>`, default: `[]`.  Pass any language class you would like
+to be kept as plain-text instead of getting highlighted.
+
 ## Contribute
 
 See [`contribute.md` in `rehypejs/rehype`][contribute] for ways to get started.

--- a/test.js
+++ b/test.js
@@ -213,6 +213,63 @@ test('highlight()', function (t) {
     'should not highlight (`nohighlight`)'
   );
 
+  t.throws(
+    function () {
+      rehype()
+        .data('settings', {fragment: true})
+        .use(highlight)
+        .processSync([
+          '<h1>Hello World!</h1>',
+          '',
+          '<pre><code class="lang-foobar">var name = "World";',
+          'console.log("Hello, " + name + "!")</code></pre>'
+        ].join('\n'))
+        .toString();
+    },
+    'Unknown language: `foobar` is not registered',
+    'should throw on missing languages'
+  );
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(highlight, {ignoreMissing: true})
+      .processSync([
+        '<h1>Hello World!</h1>',
+        '',
+        '<pre><code class="lang-foobar">var name = "World";',
+        'console.log("Hello, " + name + "!")</code></pre>'
+      ].join('\n'))
+      .toString(),
+    [
+      '<h1>Hello World!</h1>',
+      '',
+      '<pre><code class="hljs lang-foobar">var name = "World";',
+      'console.log("Hello, " + name + "!")</code></pre>'
+    ].join('\n'),
+    'should ignore missing languages'
+  );
+
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(highlight, {plainText: ['js']})
+      .processSync([
+        '<h1>Hello World!</h1>',
+        '',
+        '<pre><code class="lang-js">var name = "World";',
+        'console.log("Hello, " + name + "!")</code></pre>'
+      ].join('\n'))
+      .toString(),
+    [
+      '<h1>Hello World!</h1>',
+      '',
+      '<pre><code class="lang-js">var name = "World";',
+      'console.log("Hello, " + name + "!")</code></pre>'
+    ].join('\n'),
+    'should not highlight plainText-ed languages'
+  );
+
   t.equal(
     rehype()
       .data('settings', {fragment: true})


### PR DESCRIPTION
Hey! I'm not sure that's the best way of fixing the issue demoed here: https://github.com/vhf/remark-rehype-highlight-issue

This PR is just a suggestion, please tell me what you think!