### PR TITLE
Add a way to configure custom languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ function attacher(options) {
   var prefix = settings.prefix
   var ignoreMissing = settings.ignoreMissing
   var plainText = settings.plainText || []
+  var aliases = settings.aliases || {}
+  lowlight.registerAlias(aliases)
   var name = 'hljs'
   var pos
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "hast-util-to-string": "^1.0.0",
-    "lowlight": "^1.2.0",
+    "lowlight": "^1.10.0",
     "unist-util-visit": "^1.1.0"
   },
   "devDependencies": {
@@ -33,7 +33,8 @@
     "remark-preset-wooorm": "^4.0.0",
     "tape": "^4.0.0",
     "tinyify": "^2.4.3",
-    "xo": "^0.21.0"
+    "xo": "^0.21.0",
+    "highlight.js": "~9.12.0"
   },
   "scripts": {
     "format": "remark . -qfo && prettier --write '**/*.js' && xo --fix",

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,13 @@ with unknown code languages.
 `Array.<string>`, default: `[]`.  Pass any languages you would like to be kept
 as plain-text instead of getting highlighted.
 
+###### `options.aliases`
+
+`Map.<string, string | Array.<string>>`, default: `{}`. 
+Add your custom languages or aliases for example
+`{extraLanguages: {tex: 'latex'}}` or
+`{extraLanguages: {tex: ['latex', 'lualatex']}}`.
+
 ## Contribute
 
 See [`contributing.md` in `rehypejs/rehype`][contribute] for ways to get

--- a/test.js
+++ b/test.js
@@ -315,21 +315,44 @@ test('highlight()', function(t) {
   t.equal(
     rehype()
       .data('settings', {fragment: true})
+      .use(highlight, {
+        aliases: {tex: ['latex']}
+      })
+      .processSync(
+        [
+          '<pre><code class="lang-latex">\\begin{document}',
+          '\\end{document}</code></pre>'
+        ].join('\n')
+      )
+      .toString(),
+    [
+      '<pre><code class="hljs lang-latex"><span class="hljs-tag">',
+      '\\<span class="hljs-name">begin</span><span class="hljs-string">{document}</span>',
+      '</span>\n<span class="hljs-tag">\\<span class="hljs-name">end</span>',
+      '<span class="hljs-string">{document}</span></span></code></pre>'
+    ].join(''),
+    'should parse custom language'
+  )
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
       .use(highlight)
       .processSync(
         [
           '<h1>Hello World!</h1>',
           '',
-          '<pre><code><!--TODO-->"use strict";</code></pre>'
+          '<pre><code class="hljs lang-js"><span class="hljs-keyword">var</span> name = <span class="hljs-string">"World"</span>;',
+          '<span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Hello, "</span> + name + <span class="hljs-string">"!"</span>)</code></pre>'
         ].join('\n')
       )
       .toString(),
     [
       '<h1>Hello World!</h1>',
       '',
-      '<pre><code class="hljs language-javascript"><span class="hljs-meta">"use strict"</span>;</code></pre>'
+      '<pre><code class="hljs lang-js"><span class="hljs-keyword">var</span> name = <span class="hljs-string">"World"</span>;',
+      '<span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Hello, "</span> + name + <span class="hljs-string">"!"</span>)</code></pre>'
     ].join('\n'),
-    'should ignore comments'
+    'should reprocess exact'
   )
 
   t.end()


### PR DESCRIPTION
Hi,

Using rehype-highlight I faced this need : adding a custom language to
the parsable ones.

Highlight allows us to do such a thing, so I added a setting to rehype-highlight to
perform this configuration.