### PR TITLE
Add support for registering languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,19 @@ function attacher(options) {
   var ignoreMissing = settings.ignoreMissing
   var plainText = settings.plainText || []
   var aliases = settings.aliases
+  var languages = settings.languages
   var name = 'hljs'
   var pos
 
   if (aliases) {
     lowlight.registerAlias(aliases)
+  }
+
+  if (languages) {
+    // eslint-disable-next-line guard-for-in
+    for (let name in languages) {
+      lowlight.registerLanguage(name, languages[name])
+    }
   }
 
   if (prefix) {

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,8 @@ Passed to [`lowlight.registerAlias`][register-alias].
 ###### `options.languages`
 
 Register more languages (`Object<string | function>`, default: `{}`).
-Each key/value pair passed as arguments to [`lowlight.registerLanguage`][register-language].
+Each key/value pair passed as arguments to
+[`lowlight.registerLanguage`][register-language].
 
 ## Security
 

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,11 @@ highlighted.
 Register more aliases (`Object<string | Array.<string>>`, default: `{}`).
 Passed to [`lowlight.registerAlias`][register-alias].
 
+###### `options.languages`
+
+Register more languages (`Object<string | function>`, default: `{}`).
+Each key/value pair passed as arguments to [`lowlight.registerLanguage`][register-language].
+
 ## Security
 
 Use of `rehype-highlight` *should* be safe to use as `lowlight` *should* be safe
@@ -166,6 +171,8 @@ abide by its terms.
 [lowlight]: https://github.com/wooorm/lowlight
 
 [register-alias]: https://github.com/wooorm/lowlight#lowregisteraliasname-alias
+
+[register-language]: https://github.com/wooorm/lowlight#lowregisterlanguagename-syntax
 
 [highlight-js]: https://github.com/isagalaev/highlight.js
 

--- a/test.js
+++ b/test.js
@@ -397,5 +397,34 @@ test('highlight()', function(t) {
     'should support `<br>` elements'
   )
 
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(highlight, {
+        languages: {
+          test: function() {
+            return {
+              aliases: ['test'],
+              keywords: {keyword: 'test'}
+            }
+          }
+        }
+      })
+      .processSync(
+        [
+          '<h1>Hello World!</h1>',
+          '',
+          '<pre><code>test normal text</code></pre>'
+        ].join('\n')
+      )
+      .toString(),
+    [
+      '<h1>Hello World!</h1>',
+      '',
+      '<pre><code class="hljs language-subunit"><span class="hljs-keyword">test </span>normal text</code></pre>'
+    ].join('\n'),
+    'should register languages'
+  )
+
   t.end()
 })


### PR DESCRIPTION
Fairly straightforward feature, exposing the `registerLanguage` feature from lowlight 😀