### PR TITLE
reproduce failing scenario for when any language is specified

### DIFF
--- a/test.js
+++ b/test.js
@@ -8,6 +8,32 @@ var js = require('highlight.js/lib/languages/javascript')
 var as = require('highlight.js/lib/languages/applescript')
 var cp = require('highlight.js/lib/languages/cpp')
 
+test('options.languages', function (t) {
+  t.equal(
+    rehype()
+      .data('settings', {fragment: true})
+      .use(highlight, {
+        languages: {
+          js: js
+        }
+      })
+      .processSync(
+        ['<pre><code class="js">const two = 2;</code></pre>'].join('\n')
+      )
+      .toString(),
+    [
+      '<pre><code class="hljs js javascript">',
+      '<const>two = <span class="hljs-number">2</span>;</const>',
+      '</code></pre>'
+    ].join(
+      '\n'
+    ),
+    'empty'
+  )
+
+  t.end()
+})
+
 test('highlight()', function (t) {
   t.equal(
     rehype()


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/rehypejs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/rehypejs/.github/blob/main/support.md
https://github.com/rehypejs/.github/blob/main/contributing.md
-->

I've been trying to get some cjs integration tests written for my hljs plugin, but so far have been unsuccessful: https://github.com/NullVoxPopuli/highlightjs-glimmer/pull/35/files#diff-a14263a13ac66963bbbbe860d2028c6ea37cadba53cd5e8b2e7e08c2f0174713R28

I'm mostly wanting to use my custom grammar with rehype/remark, but so far, have had much struggle.
ref: https://github.com/remarkjs/remark/discussions/701
